### PR TITLE
Add C++ man pages

### DIFF
--- a/home/.bashrc.d/14_man
+++ b/home/.bashrc.d/14_man
@@ -1,0 +1,3 @@
+#!/usr/bin/bash
+
+export MANPATH=$MANPATH:$HOME/.local/share/man

--- a/scripts/install-packages.sh
+++ b/scripts/install-packages.sh
@@ -17,6 +17,9 @@ sudo dnf install \
      htop \
      llvm-toolset \
      mercurial \
+     qt5-qtbase-devel \
+     qt5-assistant \
+     qt5-doc \
      the_silver_searcher \
      thunderbird \
      tmux \

--- a/scripts/install-packages.sh
+++ b/scripts/install-packages.sh
@@ -15,6 +15,7 @@ sudo dnf install \
      git \
      gnome-shell-extension-system-monitor-applet \
      htop \
+     libstdc++-docs \
      llvm-toolset \
      mercurial \
      qt5-qtbase-devel \


### PR DESCRIPTION
Doesn't seem possible to have Qt5 man pages.  Not sure why I thought that you could. 

While here, added the STL man pages via package

Resolves #15 